### PR TITLE
Add sim threshold table to complete user story #12

### DIFF
--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -13,6 +13,17 @@
           <p class="whitespace-pre text-sm">Fully written out names get unhidden.</p>
         </template>
       </ToolTipComponent>
+      <ToolTipComponent direction="bottom" class="min-w-[50%] flex-grow">
+        <template #default>
+          <SimThresBarComponent placeholder="Filter/Unhide Comparisons" />
+        </template>
+        <template #tooltip>
+          <p class="whitespace-pre text-sm">
+            Type in the name of a submission to only show comparisons that contain this submission.
+          </p>
+          <p class="whitespace-pre text-sm">Fully written out names get unhidden.</p>
+        </template>
+      </ToolTipComponent>
 
       <ButtonComponent class="w-24" @click="changeAnonymousForAll()">
         {{
@@ -32,6 +43,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import SearchBarComponent from './SearchBarComponent.vue'
+import SimThresBarComponent from './SimThresBarComponent.vue'
 import ToolTipComponent from './ToolTipComponent.vue'
 import ButtonComponent from './ButtonComponent.vue'
 import OptionsSelector from './optionsSelectors/OptionsSelectorComponent.vue'

--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -15,13 +15,16 @@
       </ToolTipComponent>
       <ToolTipComponent direction="bottom" class="min-w-[50%] flex-grow">
         <template #default>
-          <SimThresBarComponent placeholder="Filter/Unhide Comparisons" />
+          <SimThresBarComponent
+            placeholder="Enter threshold filter percentage"
+            @update:similarityThreshold="handleThresholdChange"
+          />
         </template>
         <template #tooltip>
           <p class="whitespace-pre text-sm">
-            Type in the name of a submission to only show comparisons that contain this submission.
+            Enter an integer between 0-100 and all submissions with that similarity percentage or
+            lower will be filtered out.
           </p>
-          <p class="whitespace-pre text-sm">Fully written out names get unhidden.</p>
         </template>
       </ToolTipComponent>
 
@@ -63,12 +66,11 @@ const props = defineProps({
   header: {
     type: String,
     default: 'Top Comparisons:'
-  }
+  },
+  threshold: Number
 })
 
-const emit = defineEmits<{
-  (e: 'update:searchString', v: string): void
-}>()
+const emit = defineEmits(['update:searchString', 'update:threshold'])
 
 const searchStringValue = computed({
   get: () => props.searchString,
@@ -131,5 +133,9 @@ function changeAnonymousForAll() {
   } else {
     store().state.anonymous = new Set(store().getSubmissionIds)
   }
+}
+
+function handleThresholdChange(value: Number) {
+  emit('update:threshold', value)
 }
 </script>

--- a/report-viewer/src/components/SimThresBarComponent.vue
+++ b/report-viewer/src/components/SimThresBarComponent.vue
@@ -3,19 +3,20 @@
     <FontAwesomeIcon
       :icon="['fas', 'magnifying-glass']"
       class="text-gray-500"
-      @click="emit('searchClicked', parseFloat(inputText))"
+      @click="handleSearchClick"
     />
     <input
       type="number"
       class="flex-auto border-0 bg-transparent outline-none placeholder:text-gray-500"
       :placeholder="placeholder"
       v-model="inputText"
+      @input="handleInputChange"
     />
   </Interactable>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref } from 'vue'
 import Interactable from './InteractableComponent.vue'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -23,31 +24,18 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faMagnifyingGlass)
 
-const props = defineProps({
-  placeholder: {
-    type: String,
-    default: 'Enter similarity threshold',
-    required: false
-  },
-  modelValue: {
-    type: Number,
-    default: 0,
-    required: false
-  }
-})
+const emit = defineEmits(['update:similarityThreshold'])
 
-const emit = defineEmits<{
-  (e: 'inputChanged', v: number): void
-  (e: 'searchClicked', v: number): void
-  (e: 'update:modelValue', v: number): void
-}>()
+const inputText = ref('')
 
-const inputText = computed({
-  get: () => props.modelValue.toString(),
-  set: (value) => {
-    const numValue = parseFloat(value)
-    emit('update:modelValue', numValue)
-    emit('inputChanged', numValue)
-  }
-})
+function handleInputChange() {
+  const numValue = parseFloat(inputText.value) || 0
+  emit('update:similarityThreshold', numValue)
+}
+
+// Define the handleSearchClick function to emit the current value
+function handleSearchClick() {
+  const numValue = parseFloat(inputText.value) || 0
+  emit('update:similarityThreshold', numValue)
+}
 </script>

--- a/report-viewer/src/components/SimThresBarComponent.vue
+++ b/report-viewer/src/components/SimThresBarComponent.vue
@@ -1,0 +1,53 @@
+<template>
+  <Interactable class="flex flex-row items-center space-x-2 px-2 py-2">
+    <FontAwesomeIcon
+      :icon="['fas', 'magnifying-glass']"
+      class="text-gray-500"
+      @click="emit('searchClicked', parseFloat(inputText))"
+    />
+    <input
+      type="number"
+      class="flex-auto border-0 bg-transparent outline-none placeholder:text-gray-500"
+      :placeholder="placeholder"
+      v-model="inputText"
+    />
+  </Interactable>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import Interactable from './InteractableComponent.vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faMagnifyingGlass)
+
+const props = defineProps({
+  placeholder: {
+    type: String,
+    default: 'Enter similarity threshold',
+    required: false
+  },
+  modelValue: {
+    type: Number,
+    default: 0,
+    required: false
+  }
+})
+
+const emit = defineEmits<{
+  (e: 'inputChanged', v: number): void
+  (e: 'searchClicked', v: number): void
+  (e: 'update:modelValue', v: number): void
+}>()
+
+const inputText = computed({
+  get: () => props.modelValue.toString(),
+  set: (value) => {
+    const numValue = parseFloat(value)
+    emit('update:modelValue', numValue)
+    emit('inputChanged', numValue)
+  }
+})
+</script>


### PR DESCRIPTION
# Pull request to resolve user story #12: 
## Add similarity threshold filter to the submission list on the report viewer

### What?!

This adds a second search bar under the original search bar. The new bar takes in an integer input. This integer is the similarity threshold, all submissions that have a simliarity of equal or lower values will be filtered out of the list.

---
### Why?!

This allows for quick filtering of submissions. For example, if you are a professor and you want to fail anyone who has more than 50% similiarity, you just enter 50 and fail everyone in the list. Failing has never been so easy!

---
### How?!

The comparsion table component now has a brand new component in it titled SimThresBarComponent.vue. SimThresBarComponent.vue is a search bar input that changes the threshold number that is constantly be monitored by ComparisonTableFilter.vue who is ready to update the table immediately on any change.

---
### Where?!
#### Files modified:
- report-viewer/src/components/ComparisonTableFilter.vue
- report-viewer/src/components/ComparisonsTable.vue
- report-viewer/src/components/SimThresBarComponent.vue

#### This pull request resolves #12 user story by:

- **Resolve issue #9:** Add threshold input and populate list button to the bottom of the threshold list window
- **Resolve issue #10:** Implementing threshold list functionality/filtering by threshold value
- **Resolve issue #11:** (Originally) Add a list window to hold the users above a selected similarity threshold
    (Modified to) Combine filters into one list window
---
### TL;DR:
All together this pull request implements the #12 user story. That is it adds a second search bar that takes in an integer and removes any submission from the list that have a similarity score equal or less than that integer. This allows for two search criteria to filter the list simultaneously. 

